### PR TITLE
[_]: bugfix/Fix save android files and added documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/mobile-sdk",
-  "version": "0.3.0-alpha.0",
+  "version": "0.3.1",
   "description": "test",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
- Added application/octet-stream as fallback MIME type when contentResolver.getType() returns null. This prevents SQL insert failures in MediaStore when saving empty files or files with unrecognized extensions to the Downloads directory

Changed `saveFileToDownloadsDirectory` to not crash when download empty files: 
- Android 10 and above versions: Uses Scoped Storage with ContentResolver.insert() - now with MIME type fallback
- Android 9 and below: Uses direct file access with unique filename generation to prevent overwrites 